### PR TITLE
dependabotの設定をdailyに戻した

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: bundler
     directory: '/'
     schedule:
-      interval: hourly
+      interval: daily
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: hourly
+      interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
issue #242 

そもそも、`hourly`はなかった。
再生成されたものをマージしたので戻した。