### PR TITLE
fly.ioのボリューム設定をshared-cpu-1xに変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -51,4 +51,4 @@ console_command = '/rails/bin/rails console'
       X-Forwarded-Proto = 'https'
 
 [[vm]]
-  size = 'shared-cpu-1x'
+  size = 'shared-cpu-1x' 


### PR DESCRIPTION
#288 

ボリュームサイズを下げた。