### PR TITLE
終わったレッスンでも次のレッスンが来るまで表示する

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -32,7 +32,7 @@ class SchedulesController < ApplicationController
   end
 
   def set_schedules
-    @schedules = Schedule.where(student: current_user.students).limited_upcoming_lessons
+    @schedules = Schedule.where(student: current_user.students).display_lessons
   end
 
   def set_schedule

--- a/app/controllers/students/schedules_controller.rb
+++ b/app/controllers/students/schedules_controller.rb
@@ -3,6 +3,6 @@ class Students::SchedulesController < ApplicationController
 
   def show
     @student = current_user.students.find(params[:id])
-    @schedules = @student.schedules.limited_upcoming_lessons
+    @schedules = @student.schedules.display_lessons
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -14,7 +14,11 @@ class Schedule < ApplicationRecord
 
   MAX_UPCOMING_LESSONS = 4
 
-  scope :limited_upcoming_lessons, -> { where('start_at >= ?', Time.current).order(:start_at).limit(MAX_UPCOMING_LESSONS) }
+  scope :display_lessons, -> {
+    upcoming_ids = where('start_at >= ?', Time.current).order(:start_at).limit(MAX_UPCOMING_LESSONS).pluck(:id)
+    last_ended_id = where('start_at < ?', Time.current).order(start_at: :desc).limit(1).pluck(:id)
+    where(id: upcoming_ids + last_ended_id).order(:start_at)
+  }
 
   def update_google_event(admin)
     service = self.class.google_calendar_service_for(admin)

--- a/test/controllers/schedules_controller_test.rb
+++ b/test/controllers/schedules_controller_test.rb
@@ -42,14 +42,22 @@ class SchedulesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to schedules_path
   end
 
-  test 'should display from today' do
+  test 'should display upcoming lessons and last ended lesson' do
+    second_last_ended_lesson = Schedule.create!(
+      student: @student,
+      summary: '2回前のレッスン',
+      google_event_id: 'second_last_ended_lesson',
+      start_at: @yesterday_lesson.start_at - 1.second
+    )
+
     get schedules_path
 
     assert_response :success
 
-    upcoming_schedules = @student.schedules.limited_upcoming_lessons
+    display_schedules = @student.schedules.display_lessons
 
-    assert_includes upcoming_schedules, @tomorrow_lesson
-    refute_includes upcoming_schedules, @yesterday_lesson
+    assert_includes display_schedules, @tomorrow_lesson
+    assert_includes display_schedules, @yesterday_lesson
+    refute_includes display_schedules, second_last_ended_lesson
   end
 end

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -10,39 +10,38 @@ class ScheduleTest < ActiveSupport::TestCase
     @schedules = @student.schedules
   end
 
-  test 'should display from today' do
-    yesterday = Schedule.create!(
+  test 'should display upcoming lessons and last ended lesson' do
+    last_ended_lesson = Schedule.create!(
       student: @student,
       summary: 'ボブの昨日のレッスン',
-      google_event_id: 'yesterday_lesson',
+      google_event_id: 'last_ended_lesson',
       start_at: Time.current - 1.day
     )
 
-    tomorrow = Schedule.create!(
+    second_last_ended_lesson = Schedule.create!(
       student: @student,
-      summary: 'ボブの明日のレッスン',
-      google_event_id: 'tomorrow_lesson',
-      start_at: Time.current + 1.day
+      summary: 'ボブの2回前のレッスン',
+      google_event_id: 'second_last_ended_lesson',
+      start_at: last_ended_lesson.start_at - 1.second
     )
 
-    upcoming_schedules = Schedule.limited_upcoming_lessons
+    display_schedules = @student.schedules.display_lessons
 
-    assert_includes upcoming_schedules, tomorrow
-    refute_includes upcoming_schedules, yesterday
+    assert_includes display_schedules, last_ended_lesson
+    refute_includes display_schedules, second_last_ended_lesson
   end
 
-  test 'should dispaly limited upcoming lessons' do
-    limited_upcoming_schedules = @schedules.limited_upcoming_lessons
+  test 'should display limited lessons' do
+    limited_schedules = @schedules.display_lessons
 
-    assert_operator limited_upcoming_schedules.count, :<=, 8
-    refute_operator limited_upcoming_schedules.count, :>=, 9
+    assert_operator limited_schedules.count, :<=, Schedule::MAX_UPCOMING_LESSONS + 1
   end
 
   test 'should order lessons from old to new' do
-    bob_schedules = @student.schedules.limited_upcoming_lessons
+    bob_schedules = @student.schedules.display_lessons
 
     assert_equal schedules(:bob_first_schedule), bob_schedules.first
-    assert_equal schedules(:bob_eighth_schedule), bob_schedules.last
+    assert_equal schedules(:bob_fourth_schedule), bob_schedules.last
   end
 
   test 'should update google event' do
@@ -68,7 +67,7 @@ class ScheduleTest < ActiveSupport::TestCase
   end
 
   test 'should be google_calendar_service_for' do
-   @admin.google_refresh_token = 'alice_refresh_token'
+    @admin.google_refresh_token = 'alice_refresh_token'
 
     service = Schedule.google_calendar_service_for(@admin)
 


### PR DESCRIPTION
#389 
limited_upcoming_lessonsをdisplay_lessonsに変更。
現在時刻よりも前のレッスンを一つ取得し、表示できるようにした。