### PR TITLE
テストの修正とmockの整理をした

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           RAILS_ENV: test
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare; test test:system
+        run: bin/rails db:test:prepare && bin/rails test
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v6

--- a/test/controllers/schedules_controller_test.rb
+++ b/test/controllers/schedules_controller_test.rb
@@ -42,6 +42,12 @@ class SchedulesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to schedules_path
   end
 
+  test 'should get index' do
+    get schedules_path
+
+    assert_response :success
+  end
+
   test 'should display upcoming lessons and last ended lesson' do
     second_last_ended_lesson = Schedule.create!(
       student: @student,
@@ -51,8 +57,6 @@ class SchedulesControllerTest < ActionDispatch::IntegrationTest
     )
 
     get schedules_path
-
-    assert_response :success
 
     display_schedules = @student.schedules.display_lessons
 

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'minitest/mock'
 
 class ScheduleTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -47,14 +46,13 @@ class ScheduleTest < ActiveSupport::TestCase
   test 'should update google event' do
     lesson = schedules(:bob_first_schedule)
 
-    google_mock = Minitest::Mock.new
-    google_mock.expect(:update_event, true, [ 'primary', lesson.google_event_id, Google::Apis::CalendarV3::Event ])
+    google_mock = mock('calendar_service')
+    google_mock.expects(:update_event)
+               .with('primary', lesson.google_event_id, instance_of(Google::Apis::CalendarV3::Event))
+               .returns(true)
 
-    Schedule.stub(:google_calendar_service_for, google_mock) do
-      lesson.update_google_event(lesson.student.admin)
-    end
-
-    google_mock.verify
+    Schedule.stubs(:google_calendar_service_for).returns(google_mock)
+    lesson.update_google_event(lesson.student.admin)
   end
 
   test 'should notificate messages' do


### PR DESCRIPTION
#393 
- assertionが過多になっていたのを修正
- CIのコマンドを修正
- minitest 6.0.2で minitest/mockが廃止されたので修正