### PR TITLE
テスト環境にAREncryptionのキー設定を追加し、RAILS_MASTER_KEYなしでテストが動くようにした

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,5 +48,8 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
-  config.active_record.encryption.support_unencrypted_data = true
+  config.active_record.encryption.primary_key = 'test master key'
+  config.active_record.encryption.deterministic_key = 'test deterministic key'
+  config.active_record.encryption.key_derivation_salt = 'test key derivation salt'
+  config.active_record.encryption.encrypt_fixtures = true
 end


### PR DESCRIPTION
#430 

`fixture`に`line_channel_secret`を追加した際にtest環境のAREncryptionキーの設定をしていなかったため、`RAILS_MASTER_KEY`を持たないdependabot CIでテストが落ちていた。
